### PR TITLE
Align frontend API with available backend endpoints

### DIFF
--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -28,7 +28,6 @@ import {
 } from '@mui/material';
 import { 
   Search, 
-  Delete, 
   Refresh, 
   Event, 
   LocationOn, 
@@ -49,8 +48,7 @@ const EventList = () => {
   const [rowsPerPage, setRowsPerPage] = useState(config.DEFAULTS.PAGINATION.EVENTS_PER_PAGE);
   const [totalCount, setTotalCount] = useState(0);
   const [searchTerm, setSearchTerm] = useState('');
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [eventToDelete, setEventToDelete] = useState(null);
+
   const [selectedPageId, setSelectedPageId] = useState('');
 
   // Fetch events on component mount and when pagination changes
@@ -98,35 +96,7 @@ const EventList = () => {
     fetchEvents();
   };
 
-  // Handle event deletion
-  const handleDeleteEvent = async () => {
-    if (!eventToDelete) return;
-    
-    setLoading(true);
-    try {
-      await eventApi.deleteEvent(eventToDelete.id);
-      setEvents(events.filter(event => event.id !== eventToDelete.id));
-      setSuccessMessage(`Event "${eventToDelete.name}" deleted successfully!`);
-      setDeleteDialogOpen(false);
-      setEventToDelete(null);
-    } catch (err) {
-      setError(err.response?.data?.message || 'Error deleting event. Please try again.');
-    } finally {
-      setLoading(false);
-    }
-  };
 
-  // Open delete confirmation dialog
-  const openDeleteDialog = (event) => {
-    setEventToDelete(event);
-    setDeleteDialogOpen(true);
-  };
-
-  // Close delete confirmation dialog
-  const closeDeleteDialog = () => {
-    setDeleteDialogOpen(false);
-    setEventToDelete(null);
-  };
 
   // Format date and time
   const formatDateTime = (dateTimeStr) => {
@@ -281,16 +251,7 @@ const EventList = () => {
                           <OpenInNew />
                         </IconButton>
                       </Tooltip>
-                      <Tooltip title="Delete Event">
-                        <IconButton 
-                          color="error" 
-                          size="small"
-                          onClick={() => openDeleteDialog(event)}
-                          disabled={loading}
-                        >
-                          <Delete />
-                        </IconButton>
-                      </Tooltip>
+
                     </TableCell>
                   </TableRow>
                 ))}
@@ -315,26 +276,7 @@ const EventList = () => {
         </Paper>
       )}
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog
-        open={deleteDialogOpen}
-        onClose={closeDeleteDialog}
-      >
-        <DialogTitle>Delete Event</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Are you sure you want to delete the event "{eventToDelete?.name}"? This action cannot be undone.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeDeleteDialog} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleDeleteEvent} color="error" autoFocus>
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+
 
       {/* Success message */}
       <Snackbar 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -118,21 +118,12 @@ export const eventApi = {
     }
   },
 
-  // Delete an event
-  deleteEvent: async (eventId) => {
-    try {
-      const response = await api.delete(`/events/${eventId}`);
-      return response.data;
-    } catch (error) {
-      console.error('Error deleting event:', error);
-      throw error;
-    }
-  },
-
-  // Get events for a specific page
+  // Get events for a specific page (using filter parameter instead of dedicated endpoint)
   getPageEvents: async (pageId, params = {}) => {
     try {
-      const response = await api.get(`/pages/${pageId}/events`, { params });
+      // Use the events endpoint with page_id filter parameter
+      const queryParams = { ...params, page_id: pageId };
+      const response = await api.get('/events/', { params: queryParams });
       return response.data;
     } catch (error) {
       console.error('Error getting page events:', error);


### PR DESCRIPTION
This PR updates the frontend API service to properly use the available backend endpoints.\n\nChanges include:\n\n1. **API Service Updates**:\n   - Modified `getPageEvents` to use the events endpoint with page_id filter parameter instead of a dedicated endpoint\n   - Removed `deleteEvent` method as the backend doesn't support this functionality\n\n2. **EventList Component Updates**:\n   - Removed delete functionality from the UI since it's not supported by the backend\n   - Removed delete dialog and related state\n\nThis PR ensures that the frontend only uses endpoints that are actually available in the backend service, making the integration more robust.